### PR TITLE
changed font layout on bigger screens

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -219,7 +219,7 @@ h6 {
   align-items: center;
   justify-content: space-between;
   padding: 0 3px;
-  font-size: 15px;
+  font-size: 18px;
   font-weight: 600;
   color: #222222;
   white-space: nowrap;
@@ -454,11 +454,14 @@ h6 {
   font-size: 24px;
   font-weight: 400;
 }
+
+#hero a {
+  font-size: 30px;
+}
 #hero .btn-get-started {
   font-family: 'Roboto', sans-serif;
-  text-transform: uppercase;
   font-weight: 500;
-  font-size: 14px;
+  font-size: 18px;
   letter-spacing: 1px;
   display: inline-block;
   padding: 10px 28px;
@@ -471,7 +474,7 @@ h6 {
   background: #85754d;
 }
 #hero .btn-watch-video {
-  font-size: 16px;
+  font-size: 18px;
   transition: 0.5s;
   margin-left: 25px;
   color: #222222;
@@ -538,7 +541,7 @@ section {
   padding-bottom: 30px;
 }
 .section-title h2 {
-  font-size: 13px;
+  font-size: 25px;
   letter-spacing: 1px;
   font-weight: 700;
   padding: 8px 20px;
@@ -1654,7 +1657,7 @@ section {
   position: relative;
   background-color: #46489c;
   border-radius: 4em;
-  font-size: 12px;
+  font-size: 15px;
   color: white;
   padding: 0.8em 1.2em;
   cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -71,13 +71,13 @@
 
       <nav id="navbar" class="navbar">
         <ul>
-          <li><a class="nav-link scrollto active" href="#hero">Home</a></li>
-          <li><a class="nav-link scrollto" href="#about">About</a></li>
-          <li><a class="nav-link scrollto" href="#assessment">Assessment</a></li>
-          <li><a class="nav-link scrollto " href="#portfolio">News</a></li>
-          <li><a class="nav-link scrollto" href="#team">Team</a></li>
+          <li><a class="nav-link scrollto active" href="#hero">HOME</a></li>
+          <li><a class="nav-link scrollto" href="#about">ABOUT</a></li>
+          <li><a class="nav-link scrollto" href="#assessment">ASSESSMENT</a></li>
+          <li><a class="nav-link scrollto " href="#portfolio">NEWS</a></li>
+          <li><a class="nav-link scrollto" href="#teamfaculty">TEAM</a></li>
 
-          <li><a class="nav-link scrollto" href="#contact">Contact</a></li>
+          <li><a class="nav-link scrollto" href="#contact">CONTACT</a></li>
         </ul>
         <i class="bi bi-list mobile-nav-toggle"></i>
       </nav><!-- .navbar -->
@@ -93,7 +93,7 @@
       <div class="d-flex">
         <a href="#assessment" class="btn-get-started scrollto">Learn about Assessments</a>
         <a href="https://iac.university/center/UW"
-          class="lightbox btn-watch-video"><span>UW's Page in the IAC database</span></a>
+          class="lightbox btn-watch-video"><span>UW's Page in the IAC Database</span></a>
       </div>
     </div>
   </section><!-- End Hero -->
@@ -207,7 +207,7 @@
             <div class="count-box">
               <i class="bi bi-headset"></i>
               <span data-purecounter-start="0" data-purecounter-end="5"
-                data-purecounter-duration="1" class="purecounter"></span>
+                data-purecounter-duration="0.5" class="purecounter"></span>
               <p>Million USD Savings</p>
             </div>
           </div>
@@ -216,7 +216,7 @@
             <div class="count-box">
               <i class="bi bi-people"></i>
               <span data-purecounter-start="0" data-purecounter-end="2"
-                data-purecounter-duration="1" class="purecounter"></span>
+                data-purecounter-duration="0.5" class="purecounter"></span>
               <p>Tbtu Energy Saving</p>
             </div>
           </div>
@@ -263,7 +263,7 @@
 
         <div class="section-title">
           <h2>Assessments</h2>
-          <h3>Check our <span>Assessments</span></h3>
+          <h3>Check Our <span>Assessments</span></h3>
           <p>The goal of our interdisciplinary team of faculty and students is to help you
             save on
             energy costs by identifying
@@ -350,7 +350,7 @@
 
         <div class="section-title">
           <h2>News</h2>
-          <h3>Check our <span>New progress</span></h3>
+          <h3>Check Out Our <span>New Progress</span></h3>
         </div>
 
         <div class="row" data-aos="fade-up" data-aos-delay="100">
@@ -463,10 +463,12 @@
     </section><!-- End Portfolio Section -->
 
     <!-- ======= Testimonials Section ======= -->
-    <div class="section-title">
+    <section id="teamfaculty">
+    <div class="section-title">     
       <h2>Team</h2>
       <h3>The IAC<span> Faculty</span></h3>
     </div>
+    </section>
 
     <section id="testimonials" class="testimonials">
       <div class="container" data-aos="zoom-in">
@@ -590,7 +592,6 @@
       <div class="container" data-aos="fade-up">
 
         <div class="section-title">
-          <h2>Team</h2>
           <h3>IAC <span>Students</span></h3>
         </div>
 
@@ -886,8 +887,8 @@
               <button
                 onclick="AdvancedCopy('215K ECE, Campus Box 352500, University of Washington, Seattle WA 98195')"
                 class="button">
-                <span tabindex="0" data-descr="Click to Copy">215K ECE, Campus Box 352500,
-                  University of Washington, Seattle WA 98195</span>
+                <p><span tabindex="0" data-descr="Click to Copy">215K ECE, Campus Box 352500,
+                  University of Washington, Seattle WA 98195</span></p>
               </button>
             </div>
           </div>
@@ -897,8 +898,8 @@
               <i class="bx bx-envelope"></i>
               <h3>Email Us</h3>
               <button class="button" onclick="AdvancedCopy('mamishev@ece.uw.edu')">
-                <span tabindex="0" data-descr="Click to Copy">mamishev<i
-                    class="fa fa-at"></i>ece.uw.edu</span>
+                <p><span tabindex="0" data-descr="Click to Copy">mamishev<i
+                    class="fa fa-at"></i>ece.uw.edu</span></p>
               </button>
             </div>
           </div>
@@ -908,8 +909,8 @@
               <i class="bx bx-phone-call"></i>
               <h3>Call Us</h3>
               <button class="button" onclick="AdvancedCopy('2062215729')">
-                <span tabindex="0" data-descr="Click to Copy">(206) 221-5729</span>
-              </button>
+                <p><span tabindex="0" data-descr="Click to Copy">(206) 221-5729</span>
+              </button></p>
             </div>
           </div>
 


### PR DESCRIPTION
I looked at the IAC website on the largest monitor I have access to and made the following changes: 
- changed the size of the nav bar font from 15px to 18px and to all uppercase for better clarity
- changed the section title to font size from 13px to 25px [felt like as a section title, the font size needs to be bigger. it informs the audience that they have entered to a different section of the website.]
- removed the duplicate of the "TEAM" section title above "The IAC Faculty" and "IAC Students"
- when you click on "TEAM" on the navbar, it automatically directs you to the IAC Students and ignores the upper section of the IAC Faculty. Corrected it to go to IAC Faculty instead of IAC Students straight away. 
- fixed the h3 under section title to have every first letter be Uppercase to be consistent throughout the webpage.
- increased the font of the "hero" part (home section) - more specifically the "Learn about Assessments"(all uppercase to CamelCase) and "UW's Page in the IAC Database"
- increased the font in the buttons in "Contact" section and "Join Our Team" section